### PR TITLE
Ignore html in message text

### DIFF
--- a/i18n-msg.html
+++ b/i18n-msg.html
@@ -119,7 +119,7 @@ If an appropriate message file can't be found, the `textContent` of the element 
     attached: function() {
       var msg = this.locales[this.language] && this.locales[this.language][this.msgid];
       if (msg && msg.message) {
-        this.innerHTML = msg.message;
+        this.innerText = msg.message;
       }
     },
 
@@ -163,7 +163,7 @@ If an appropriate message file can't be found, the `textContent` of the element 
           continue;
         }
 
-        instance.innerHTML = instance.locales[instance.language][instance.msgid].message;
+        instance.innerText = instance.locales[instance.language][instance.msgid].message;
       }
     },
 

--- a/i18n-msg.html
+++ b/i18n-msg.html
@@ -119,7 +119,7 @@ If an appropriate message file can't be found, the `textContent` of the element 
     attached: function() {
       var msg = this.locales[this.language] && this.locales[this.language][this.msgid];
       if (msg && msg.message) {
-        this.innerText = msg.message;
+        this.textContent = msg.message;
       }
     },
 
@@ -163,7 +163,7 @@ If an appropriate message file can't be found, the `textContent` of the element 
           continue;
         }
 
-        instance.innerText = instance.locales[instance.language][instance.msgid].message;
+        instance.textContent = instance.locales[instance.language][instance.msgid].message;
       }
     },
 


### PR DESCRIPTION
I'm surprised that i18n-msg uses very insecure and inefficient innerHTML property of the tag! I guess, for internationalization you don't really want any HTML tags in messages. The translation might even be outsourced to someone who don't know what `&lt;` and `&amp;` mean. I don't think people should be forced to deal with the chain of encodings text -> HTML -> JS. Dealing with `\"` alone is already a problem.
Chrome chrome.i18n also recommends innerText over innerHTML.