### PR TITLE
Polymer 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components
 node_modules
+.idea

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-msg",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "authors": [
     "Eric Bidelman <ebidel@>"
   ],
@@ -22,14 +22,10 @@
     "/tests/"
   ],
   "dependencies": {
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.6.0",
-    "polymer": "Polymer/polymer#0.8.0-rc.7",
+    "polymer": "Polymer/polymer#^1.0.0",
     "observe-js": "Polymer/observe-js"
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#master"
-  },
-  "resolutions": {
-    "webcomponentsjs": "^0.6.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-msg",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "authors": [
     "Eric Bidelman <ebidel@>"
   ],

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,8 @@
   ],
   "dependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.6.0",
-    "polymer": "Polymer/polymer#^0.5.5"
+    "polymer": "Polymer/polymer#^0.8.0-rc.4",
+    "observer-js": "Polymer/observe-js"
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#master"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-msg",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "authors": [
     "Eric Bidelman <ebidel@>"
   ],

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-msg",
-  "version": "0.0.5",
+  "version": "0.8.1",
   "authors": [
     "Eric Bidelman <ebidel@>"
   ],

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.6.0",
-    "polymer": "Polymer/polymer#^0.8.0-rc.4",
+    "polymer": "Polymer/polymer#0.8.0-rc.7",
     "observe-js": "Polymer/observe-js"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.6.0",
     "polymer": "Polymer/polymer#^0.8.0-rc.4",
-    "observer-js": "Polymer/observe-js"
+    "observe-js": "Polymer/observe-js"
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#master"

--- a/demo.html
+++ b/demo.html
@@ -17,8 +17,6 @@
 
 <p>Example fallback text when a message id isn't found: <i18n-msg msgid="UNKNOWN_MSG_ID">PLACEHOLDER_STRING</i18n-msg></b></p>
 
-<p>Example without the use of msgid attribute. The element then uses the inner html as msgid: <b><i18n-msg>hours</i18n-msg>!</b></p>
-
 <select id="selector">
   <option selected>en</option>
   <option>es</option>

--- a/demo.html
+++ b/demo.html
@@ -9,7 +9,7 @@
   <link rel="import" href="i18n-msg.html">
 
 </head>
-<body unresolved>
+<body>
 
 <p>"Days" in selected language is: <b><i18n-msg id="daysMsgEl" msgid="days">PLACEHOLDER_STRING</i18n-msg></b>!</p>
 <p>"Hours" in selected language is: <b><i18n-msg msgid="hours">PLACEHOLDER_STRING</i18n-msg></b>!</p>

--- a/demo.html
+++ b/demo.html
@@ -17,6 +17,8 @@
 
 <p>Example fallback text when a message id isn't found: <i18n-msg msgid="UNKNOWN_MSG_ID">PLACEHOLDER_STRING</i18n-msg></b></p>
 
+<p>Example without the use of msgid attribute. The element then uses the inner html as msgid: <b><i18n-msg>hours</i18n-msg>!</b></p>
+
 <select id="selector">
   <option selected>en</option>
   <option>es</option>

--- a/i18n-msg.html
+++ b/i18n-msg.html
@@ -134,7 +134,7 @@ Fired when the set language is ready.
 
             ready: function () {
                 this.language = I18nMsg.lang;
-                this.messagesUrl = I18nMsg.messagesUrl;
+                this.messagesUrl = I18nMsg.url;
 
                 // Have instances observe window.I18nMsg.lang changes
                 // and go fetch the localized messages.json file.

--- a/i18n-msg.html
+++ b/i18n-msg.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="observer.html">
 
 <!-- Copyright Eric Bidelman <ebidel@gmail.com> -->
 
@@ -22,8 +23,8 @@ Setting a language instructs `<i18n-msg>` to read message ids from a predefined
 file on your server. For example, `I18nMsg.lang = 'es'` will use `locales/es.json`.
 `I18nMsg.lang = 'fr'` would use message strings from `locales/fr.json`.
 
-The directory name can be configured by using the `messagesDir` attribute, but the file
-cannot. `<i18n-msg>` will always attempt to use messages from `<messagesDir>/<LANG_YOU_SET>.json`.
+The directory name can be configured by using the `messagesUrl` attribute, but the file
+cannot. `<i18n-msg>` will always attempt to use messages from `<messagesUrl>/<LANG_YOU_SET>.json`.
 
 <b>Note:</b> - message files are read once and reused for all instances of `<i18n-msg>`.
 
@@ -64,166 +65,198 @@ Fired when the set language is ready.
 @param {Object} detail
 @param {string} detail.language Object full of messages for the set language.
 -->
-<polymer-element name="i18n-msg" attributes="msgid messagesDir">
+<dom-module id="i18n-msg">
+</dom-module>
 <script>
-(function() {
+    (function () {
 
-  window.I18nMsg = window.I18nMsg || {
-    lang: null,
-    locales: {}
-  };
+        window.I18nMsg = window.I18nMsg || {
+            lang: null,
+            url: 'locales',
+            locales: {}
+        };
 
-  var instances = [];
+        var instances = [];
 
-  var fetching_ = false; /* If if there's an outstanding XHR fetching a locale file. */
+        var fetching_ = false;
+        /* If if there's an outstanding XHR fetching a locale file. */
 
-  var numInstancesUpdated_ = 0;
+        var numInstancesUpdated_ = 0;
 
-  Polymer({
+        Polymer({
+            is: 'i18n-msg',
 
-    /**
-     * The message id (key) for this message.
-     *
-     * @attribute msgid
-     * @type string
-     * @default null
-     */
-    msgid: null,
+            properties: {
+                /**
+                 * The message id (key) for this message.
+                 *
+                 * @attribute msgid
+                 * @type string
+                 * @default null
+                 */
+                msgid: {
+                    type: String,
+                    value: null
+                },
 
-    /**
-     * The folder name where the localized `<lang>.json` files are located.
-     *
-     * @attribute messagesDir
-     * @type string
-     * @default 'locales'
-     */
-    messagesDir: 'locales',
+                /**
+                 * The set language being used.
+                 *
+                 * @property language
+                 * @type string
+                 * @default null
+                 * @readonly
+                 */
+                language: {
+                    type: String,
+                    value: null,
+                    observer: 'languageChanged'
+                }
+            },
 
-    /**
-     * The set language being used.
-     *
-     * @property language
-     * @type string
-     * @default null
-     * @readonly
-     */
-    language: null,
+            /**
+             * The folder name where the localized `<lang>.json` files are located.
+             *
+             * @attribute messagesUrl
+             * @type string
+             * @default 'locales'
+             */
+            messagesUrl: 'locales',
 
-    /**
-     * An object containing the set of known language locales that have been loaded.
-     *
-     * @property locales
-     * @type object
-     * @default {}
-     */
-    locales: I18nMsg.locales, // static
+            /**
+             * An object containing the set of known language locales that have been loaded.
+             *
+             * @property locales
+             * @type object
+             * @default {}
+             */
+            locales: I18nMsg.locales, // static
 
-    ready: function() {
-      this.language = I18nMsg.lang;
+            ready: function () {
+                this.language = I18nMsg.lang;
+                this.messagesUrl = I18nMsg.messagesUrl;
 
-      // Have instances observe window.I18nMsg.lang changes
-      // and go fetch the localized messages.json file.
-      var observer = new PathObserver(window.I18nMsg, 'lang');
-      observer.open(function(newValue, oldValue) {
-        numInstancesUpdated_ = 0;
-        this.language = newValue;
-      }.bind(this));
+                // Have instances observe window.I18nMsg.lang changes
+                // and go fetch the localized messages.json file.
+                var observerLang = new PathObserver(window.I18nMsg, 'lang');
+                observerLang.open(function (newValue, oldValue) {
+                    numInstancesUpdated_ = 0;
+                    this.language = newValue;
+                }.bind(this));
 
-      instances.push(this);
-    },
+                // Have instances observe window.I18nMsg.lang changes
+                // and go fetch the localized messages.json file.
+                var observerUrl = new PathObserver(window.I18nMsg, 'url');
+                observerUrl.open(function (newValue, oldValue) {
+                    numInstancesUpdated_ = 0;
+                    this.messagesUrl = newValue;
 
-    attached: function() {
-      var msg = this.locales[this.language] && this.locales[this.language][this.msgid];
-      if (msg && msg.message) {
-        this.innerHTML = msg.message;
-      }
-    },
+                    if (!this.language || fetching_) {
+                        return;
+                    }
 
-    languageChanged: function() {
-      // Don't fetch .json file if it has already been
-      // fetched or another instance is already trying to.
-      if (this.language && this.locales[this.language] && !fetching_) {
-        // Send one signal that language changed to outside.
-        if (numInstancesUpdated_ == instances.length - 1) {
-          this.fire('i18n-language-ready', {langauge: this.language});
-        }
+                    this.fetchLanguage();
+                }.bind(this));
 
-        this.updateElementMessage();
-        numInstancesUpdated_++;
+                instances.push(this);
+            },
 
-        return;
-      } else if (!this.language || this.locales[this.language] || fetching_) {
-        return;
-      }
+            attached: function () {
+                var msg = this.locales[this.language] && this.locales[this.language][this.msgid];
+                if (msg && msg.message) {
+                    this.innerHTML = msg.message;
+                }
+            },
 
-      fetching_ = true;
+            languageChanged: function () {
+                // Don't fetch .json file if it has already been
+                // fetched or another instance is already trying to.
+                if (this.language && this.locales[this.language] && !fetching_) {
+                    // Send one signal that language changed to outside.
+                    if (numInstancesUpdated_ == instances.length - 1) {
+                        this.fire('i18n-language-ready', {language: this.language});
+                    }
 
-      var url = this.messagesDir + '/' + this.language + '.json';
+                    this.updateElementMessage();
+                    numInstancesUpdated_++;
 
-      var xhr = new XMLHttpRequest();
-      xhr.open('GET', url);
-      xhr.onload = function(e) {
-        if (e.target.status != 200) {
-          return;
-        }
+                    return;
+                } else if (!this.language || this.locales[this.language] || fetching_) {
+                    return;
+                }
 
-        var resp = JSON.parse(e.target.response);
-        if (!this.msgid in resp) {
-          console.warn(this.localName + ': "' + this.msgid + '" message id was not found in ' + url);
-          return;
-        }
+                this.fetchLanguage();
+            },
 
-        this.locales[this.language] = resp; // cache this locale.
+            fetchLanguage: function() {
+                fetching_ = true;
 
-        this.notifyInstances();
+                var url = this.messagesUrl + '/' + this.language + '.json';
 
-        fetching_ = false;
+                var xhr = new XMLHttpRequest();
+                xhr.open('GET', url);
+                xhr.onload = function (e) {
+                    if (e.target.status != 200) {
+                        fetching_ = false;
+                        return;
+                    }
 
-        this.fire('i18n-language-ready', {langauge: this.language});
-      }.bind(this);
-      xhr.send();
-    },
+                    var resp = JSON.parse(e.target.response);
+                    if (!this.msgid in resp) {
+                        console.warn(this.localName + ': "' + this.msgid + '" message id was not found in ' + url);
+                        return;
+                    }
 
-    updateElementMessage: function(opt_instance) {
-      var instance = opt_instance || this;
+                    this.locales[this.language] = resp; // cache this locale.
 
-      var msg = instance.locales[instance.language][instance.msgid];
-      if (msg && msg.message) {
-        instance.innerHTML = msg.message;
-      }
-    },
+                    this.notifyInstances();
 
-    notifyInstances: function() {
-      for (var i = 0, instance; instance = instances[i]; ++i) {
-        instance.language = I18nMsg.lang;
+                    fetching_ = false;
 
-        if (!instance.locales[instance.language][instance.msgid]) {
-          console.warn(this.localName + ': "' + instance.msgid + '" message id was not found');
-          continue;
-        }
+                    this.fire('i18n-language-ready', {language: this.language});
+                }.bind(this);
+                xhr.send();
+            },
 
-        this.updateElementMessage(instance);
-      }
-    },
+            updateElementMessage: function (opt_instance) {
+                var instance = opt_instance || this;
 
-    /**
-     * Returns a message in the current locale (set by `window.I18nMsg.lang`).
-     * @method getMsg
-     * @param {string=} opt_msgId Optional message id to lookup. If left off,
-     * the instance's `msgid` property is used.
-     * @return {string|null} Translated message or `null` if not found.
-     */
-    getMsg: function(opt_msgId) {
-      var msgId = opt_msgId || this.msgid;
-      var lang = this.locales[this.language];
-      if (lang && lang[msgId]) {
-        return lang[msgId].message;
-      }
-      return null;
-    }
+                var msg = instance.locales[instance.language][instance.msgid];
+                if (msg && msg.message) {
+                    instance.innerHTML = msg.message;
+                }
+            },
 
-  });
+            notifyInstances: function () {
+                for (var i = 0, instance; instance = instances[i]; ++i) {
+                    instance.language = I18nMsg.lang;
 
-})();
+                    if (!instance.locales[instance.language][instance.msgid]) {
+                        console.warn(this.localName + ': "' + instance.msgid + '" message id was not found');
+                        continue;
+                    }
+
+                    this.updateElementMessage(instance);
+                }
+            },
+
+            /**
+             * Returns a message in the current locale (set by `window.I18nMsg.lang`).
+             * @method getMsg
+             * @param {string=} opt_msgId Optional message id to lookup. If left off,
+             * the instance's `msgid` property is used.
+             * @return {string|null} Translated message or `null` if not found.
+             */
+            getMsg: function (opt_msgId) {
+                var msgId = opt_msgId || this.msgid;
+                var lang = this.locales[this.language];
+                if (lang && lang[msgId]) {
+                    return lang[msgId].message;
+                }
+                return null;
+            }
+
+        });
+
+    })();
 </script>
-</polymer-element>

--- a/i18n-msg.html
+++ b/i18n-msg.html
@@ -47,7 +47,7 @@ If an appropriate message file can't be found, the `textContent` of the element 
       </body>
     </html>
 
-### Gettting a message:
+### Getting a message:
 
     // No argument returns the instance's message:
     document.querySelector('i18n-msg').getMessage();
@@ -68,199 +68,206 @@ Fired when the set language is ready.
 <dom-module id="i18n-msg">
 </dom-module>
 <script>
-    (function () {
+  (function () {
 
-        window.I18nMsg = window.I18nMsg || {
-            lang: null,
-            url: 'locales',
-            locales: {}
-        };
+    window.I18nMsg = window.I18nMsg || {
+      lang: null,
+      url: 'locales',
+      locales: {}
+    };
 
-        var instances = [];
+    var _instances = []; /* Holds all i18n-msg elements to have them easily updated with translation messages. */
 
-        var fetching_ = false;
-        /* If if there's an outstanding XHR fetching a locale file. */
+    var _fetching = false; /* If if there's an outstanding XHR fetching a locale file. */
 
-        var numInstancesUpdated_ = 0;
+    var _numInstancesUpdated = 0;
 
-        Polymer({
-            is: 'i18n-msg',
+    Polymer({
+      is: 'i18n-msg',
 
-            properties: {
-                /**
-                 * The message id (key) for this message.
-                 *
-                 * @attribute msgid
-                 * @type string
-                 * @default null
-                 */
-                msgid: {
-                    type: String,
-                    value: null
-                },
+      properties: {
+        /**
+         * The message id (key) for this message.
+         *
+         * @attribute msgid
+         * @type string
+         * @default null
+         */
+        msgid: {
+          type: String,
+          value: null
+        },
 
-                /**
-                 * The set language being used.
-                 *
-                 * @property language
-                 * @type string
-                 * @default null
-                 * @readonly
-                 */
-                language: {
-                    type: String,
-                    value: null,
-                    observer: 'languageChanged'
-                }
-            },
+        /**
+         * The language being used.
+         *
+         * @property language
+         * @type string
+         * @default null
+         * @readonly
+         */
+        language: {
+          type: String,
+          value: null,
+          observer: 'languageChanged',
+          readOnly: true
+        },
 
-            /**
-             * The folder name where the localized `<lang>.json` files are located.
-             *
-             * @attribute messagesUrl
-             * @type string
-             * @default 'locales'
-             */
-            messagesUrl: 'locales',
+        /**
+         * The folder name where the localized `<lang>.json` files are located.
+         * Overrides `window.I18nMsg` if not `null`.
+         *
+         * @property messagesUrl
+         * @type string
+         * @default null
+         */
+        messagesUrl: {
+          type: String,
+          value: null
+        }
+      },
 
-            /**
-             * An object containing the set of known language locales that have been loaded.
-             *
-             * @property locales
-             * @type object
-             * @default {}
-             */
-            locales: I18nMsg.locales, // static
+      /**
+       * An object containing the set of known language locales that have been loaded.
+       *
+       * @property locales
+       * @type object
+       * @default {}
+       */
+      locales: I18nMsg.locales, // static
 
-            ready: function () {
-                this.language = I18nMsg.lang;
-                this.messagesUrl = I18nMsg.url;
+      ready: function() {
+        this._setLanguage(I18nMsg.lang);
+        this.messagesUrl = I18nMsg.url;
 
-                // Have instances observe window.I18nMsg.lang changes
-                // and go fetch the localized messages.json file.
-                var observerLang = new PathObserver(window.I18nMsg, 'lang');
-                observerLang.open(function (newValue, oldValue) {
-                    numInstancesUpdated_ = 0;
-                    this.language = newValue;
-                }.bind(this));
+        // Have instances observe window.I18nMsg.lang changes
+        // and go fetch the localized messages.json file.
+        var observerLang = new PathObserver(window.I18nMsg, 'lang');
+        observerLang.open(function (newValue, oldValue) {
+          _numInstancesUpdated = 0;
+          this._setLanguage(newValue);
+        }.bind(this));
 
-                // Have instances observe window.I18nMsg.lang changes
-                // and go fetch the localized messages.json file.
-                var observerUrl = new PathObserver(window.I18nMsg, 'url');
-                observerUrl.open(function (newValue, oldValue) {
-                    numInstancesUpdated_ = 0;
-                    this.messagesUrl = newValue;
+        // Have instances observe window.I18nMsg.lang changes
+        // and go fetch the localized messages.json file.
+        var observerUrl = new PathObserver(window.I18nMsg, 'url');
+        observerUrl.open(function (newValue, oldValue) {
+          _numInstancesUpdated = 0;
+          this.messagesUrl = newValue;
 
-                    if (!this.language || fetching_) {
-                        return;
-                    }
+          if (!this.language || _fetching) {
+            return;
+          }
 
-                    this.fetchLanguage();
-                }.bind(this));
+          this.fetchLanguage();
+        }.bind(this));
 
-                instances.push(this);
-            },
+        _instances.push(this);
+      },
 
-            attached: function () {
-                if (!this.msgid) {
-                    this.msgid = this.innerHTML;
-                }
+      attached: function() {
+        var msg = this.locales[this.language] && this.locales[this.language][this.msgid];
+        if (msg && msg.message) {
+          this.innerHTML = msg.message;
+        }
+      },
 
-                var msg = this.locales[this.language] && this.locales[this.language][this.msgid];
-                if (msg && msg.message) {
-                    this.innerHTML = msg.message;
-                }
-            },
+      /**
+       * The `i18n-language-ready` is fired after the locale was fetched and all `<i18n-msg>` elements were updated.
+       *
+       * @event i18n-language-ready
+       * @detail {{language: String}}
+       */
 
-            languageChanged: function () {
-                // Don't fetch .json file if it has already been
-                // fetched or another instance is already trying to.
-                if (this.language && this.locales[this.language] && !fetching_) {
-                    // Send one signal that language changed to outside.
-                    if (numInstancesUpdated_ == instances.length - 1) {
-                        this.fire('i18n-language-ready', {language: this.language});
-                    }
+      languageChanged: function() {
+        // Don't fetch .json file if it has already been
+        // fetched or another instance is already trying to.
+        if (this.language && this.locales[this.language] && !_fetching) {
+          // Send one signal that language changed to outside.
+          if (_numInstancesUpdated == _instances.length - 1) {
+            this.fire('i18n-language-ready', {language: this.language});
+          }
 
-                    this.updateElementMessage();
-                    numInstancesUpdated_++;
+          this.updateElementMessage();
+          _numInstancesUpdated++;
 
-                    return;
-                } else if (!this.language || this.locales[this.language] || fetching_) {
-                    return;
-                }
+          return;
+        } else if (!this.language || this.locales[this.language] || _fetching) {
+          return;
+        }
 
-                this.fetchLanguage();
-            },
+        this.fetchLanguage();
+      },
 
-            fetchLanguage: function() {
-                fetching_ = true;
+      fetchLanguage: function() {
+        _fetching = true;
 
-                var url = this.messagesUrl + '/' + this.language + '.json';
+        var url = this.messagesUrl + '/' + this.language + '.json';
 
-                var xhr = new XMLHttpRequest();
-                xhr.open('GET', url);
-                xhr.onload = function (e) {
-                    if (e.target.status != 200) {
-                        fetching_ = false;
-                        return;
-                    }
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', url);
+        xhr.onload = function(e) {
+          if (e.target.status != 200) {
+            _fetching = false;
+            return;
+          }
 
-                    var resp = JSON.parse(e.target.response);
-                    if (!this.msgid in resp) {
-                        console.warn(this.localName + ': "' + this.msgid + '" message id was not found in ' + url);
-                        return;
-                    }
+          var resp = JSON.parse(e.target.response);
+          if (!this.msgid in resp) {
+            console.warn(this.localName + ': "' + this.msgid + '" message id was not found in ' + url);
+            return;
+          }
 
-                    this.locales[this.language] = resp; // cache this locale.
+          this.locales[this.language] = resp; // cache this locale.
 
-                    this.notifyInstances();
+          this.notifyInstances();
 
-                    fetching_ = false;
+          _fetching = false;
 
-                    this.fire('i18n-language-ready', {language: this.language});
-                }.bind(this);
-                xhr.send();
-            },
+          this.fire('i18n-language-ready', {language: this.language});
+        }.bind(this);
+        xhr.send();
+      },
 
-            updateElementMessage: function (opt_instance) {
-                var instance = opt_instance || this;
+      updateElementMessage: function(opt_instance) {
+        var instance = opt_instance || this;
 
-                var msg = instance.locales[instance.language][instance.msgid];
-                if (msg && msg.message) {
-                    instance.innerHTML = msg.message;
-                }
-            },
+        var msg = instance.locales[instance.language][instance.msgid];
+        if (msg && msg.message) {
+          instance.innerHTML = msg.message;
+        }
+      },
 
-            notifyInstances: function () {
-                for (var i = 0, instance; instance = instances[i]; ++i) {
-                    instance.language = I18nMsg.lang;
+      notifyInstances: function() {
+        for (var i = 0, instance; instance = _instances[i]; ++i) {
+          instance.language = I18nMsg.lang;
 
-                    if (!instance.locales[instance.language][instance.msgid]) {
-                        console.warn(this.localName + ': "' + instance.msgid + '" message id was not found');
-                        continue;
-                    }
+          if (!instance.locales[instance.language][instance.msgid]) {
+            console.warn(this.localName + ': "' + instance.msgid + '" message id was not found');
+            continue;
+          }
 
-                    this.updateElementMessage(instance);
-                }
-            },
+          this.updateElementMessage(instance);
+        }
+      },
 
-            /**
-             * Returns a message in the current locale (set by `window.I18nMsg.lang`).
-             * @method getMsg
-             * @param {string=} opt_msgId Optional message id to lookup. If left off,
-             * the instance's `msgid` property is used.
-             * @return {string|null} Translated message or `null` if not found.
-             */
-            getMsg: function (opt_msgId) {
-                var msgId = opt_msgId || this.msgid;
-                var lang = this.locales[this.language];
-                if (lang && lang[msgId]) {
-                    return lang[msgId].message;
-                }
-                return null;
-            }
+      /**
+       * Returns a message in the current locale (set by `window.I18nMsg.lang`).
+       * @method getMsg
+       * @param {string=} opt_msgId Optional message id to lookup. If left off,
+       * the instance's `msgid` property is used.
+       * @return {string|null} Translated message or `null` if not found.
+       */
+      getMsg: function(opt_msgId) {
+        var msgId = opt_msgId || this.msgid;
+        var lang = this.locales[this.language];
+        if (lang && lang[msgId]) {
+          return lang[msgId].message;
+        }
+        return null;
+      }
 
-        });
+    });
 
-    })();
+  })();
 </script>

--- a/i18n-msg.html
+++ b/i18n-msg.html
@@ -162,6 +162,10 @@ Fired when the set language is ready.
             },
 
             attached: function () {
+                if (!this.msgid) {
+                    this.msgid = this.innerHTML;
+                }
+
                 var msg = this.locales[this.language] && this.locales[this.language][this.msgid];
                 if (msg && msg.message) {
                     this.innerHTML = msg.message;

--- a/observer.html
+++ b/observer.html
@@ -1,1 +1,1 @@
-<script src="bower_components/observe-js/src/observe.js"></script>
+<script src="../observe-js/src/observe.js"></script>

--- a/observer.html
+++ b/observer.html
@@ -1,0 +1,1 @@
+<script src="bower_components/observe-js/src/observe.js"></script>


### PR DESCRIPTION
I tried to migrate your element to polymer ^1.0.0. I also implemented a way to change the source url for the location files.

Other changes:
Rename messageDir to messagesUrl (more fitting in my opinion).
Added possibility to set the source url for locales on the I18nMsg object.
Added observer to automatically update elements if the source url was changed.
Fixed typo in '18n-language-ready' event. Property 'language' was misspelled.
Fixed bug where new locale files wouldn't get fetched, because the 'fetching_' flag isn't cleared if a request failed before.