### PR TITLE
Set messagesUrl before Language on ready

### DIFF
--- a/i18n-msg.html
+++ b/i18n-msg.html
@@ -121,8 +121,8 @@ If an appropriate message file can't be found, the `textContent` of the element 
     },
 
     ready: function() {
-      this._setLanguage(I18nMsg.lang);
       this.messagesUrl = I18nMsg.url;
+      this._setLanguage(I18nMsg.lang);
 
       // Have instances observe window.I18nMsg.lang changes
       // and go fetch the localized messages.json file.


### PR DESCRIPTION
Using this strategy to setup localisation the url will not be set correctly in the first `_fetchLanguage` call.

```javascript 
<script>
document.addEventListener('HTMLImportsLoaded', function() {
    I18nMsg.url = "/locales";
    I18nMsg.lang = 'es';
});
</script>
```
This pull request sets language after the messagesUrl so that when the languages observer is triggered the messageUrl will be correct and load the correct translation file.