### PR TITLE
Add msg property

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -22,7 +22,12 @@
   <option>pt-br</option>
 </select>
 
-<p>Example of updating an attribute: <input id="input" placeholder="Days"></p>
+<p>Example of updating an attribute with getMsg() method: <input id="input" placeholder="Days"></p>
+
+<template is="dom-bind">
+  <i18n-msg msgid="days" msg="{{days}}"></i18n-msg>
+  <p>Example of updating an attribute: <input id="input" placeholder="[[days]]"></p>
+</template>
 
 <p>Example of dynamically created element: <span id="dynamic"></span></p>
 

--- a/i18n-msg.html
+++ b/i18n-msg.html
@@ -122,6 +122,15 @@ If an appropriate message file can't be found, the `textContent` of the element 
       messagesUrl: {
         type: String,
         value: 'locales'
+      },
+
+      /**
+       * The message in the current locale
+       */
+      msg: {
+        type: String,
+        value: null,
+        notify: true
       }
     },
 
@@ -166,6 +175,7 @@ If an appropriate message file can't be found, the `textContent` of the element 
     attached: function() {
       var msg = this.getMsg(this.msgid)
       if (msg) {
+        this.msg = msg;
         this.innerHTML = msg;
       }
     },
@@ -253,6 +263,7 @@ If an appropriate message file can't be found, the `textContent` of the element 
 
       var msg = instance.locales[instance.language][instance.msgid];
       if (msg && msg.message) {
+        instance.msg = msg.message;
         instance.innerHTML = msg.message;
       }
     },

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -36,6 +36,10 @@
         assert.equal(el.getMsg(), expected); // no args returns instance's message
       });
 
+      test('msg property is correctly setted', function() {
+        assert.equal(el.msg, expected);
+      });
+
       test('.language property matches I18nMsg.lang', function() {
         assert.equal(el.language, I18nMsg.lang);
       });


### PR DESCRIPTION
Add a `msg` which updated with the message in the current locale.

Add a `noHtml` property because we don't want to see the message in the `el.textContent` when we use the msg property.
If you have a better name for this property, don't hesitate to tell me.