### PR TITLE
fix(i18n-msg.hmtl): bypass response code 0

### DIFF
--- a/i18n-msg.html
+++ b/i18n-msg.html
@@ -226,7 +226,7 @@ If an appropriate message file can't be found, the `textContent` of the element 
       xhr.onload = function(e) {
         _fetching = false;
 
-        if (e.target.status !== 200) {
+        if (e.target.status !== 200 && e.target.status !== 0) {
           return;
         }
 


### PR DESCRIPTION
Bypasses response code 0 when `file` protocol is explicitly defined or component is used under Cordova/Phonegap environments.