### PR TITLE
Nested dynamic values within messages

### DIFF
--- a/i18n-msg.html
+++ b/i18n-msg.html
@@ -49,6 +49,22 @@ If an appropriate message file can't be found, the `textContent` of the element 
 
     <i18n-msg msgid="unknownmsgid">fallback text</i18n-msg>
 
+### Parameters
+
+It's possible to insert text within the message which requires no translation (e.g: names, dates, numbers).
+To make available the use of parameters the message must contains $n (being n a numeric value) whenever a parameter
+should be used, and to use these add the attribute "parameters" and separate each parameter with ";;". Example:
+JSON
+    "textwithparameters" {
+      "description" : "...",
+      "message" : "I am $0 and I live in $1"
+    }
+
+HTML
+    <i18-msg msgid="textwithparameters" paremeters="John Doe;;Seattle"></i18n-msg>
+
+It's also possible to use {{}} and [[]] within the parameters.
+
 ### Full example
 
     <html lang="es">
@@ -103,6 +119,16 @@ If an appropriate message file can't be found, the `textContent` of the element 
         type: String,
         value: null,
         observer: '_msgidChanged'
+      },
+
+      /**
+       * Parameters used to insert within the message if it contains replacement
+       * patterns to switch with.
+       */
+      parameters: {
+        type: String,
+        value: null,
+        observer: '_parametersChanged'
       },
 
       /**
@@ -192,6 +218,12 @@ If an appropriate message file can't be found, the `textContent` of the element 
       }
     },
 
+    _parametersChanged: function() {
+      if (this.language && this.locales[this.language] && this.parameters) {
+        this._updateElementMessage(this);
+      }
+    },
+
     _languageChanged: function() {
       // Don't fetch .json file if it has already been
       // fetched or another instance is already trying to.
@@ -253,6 +285,14 @@ If an appropriate message file can't be found, the `textContent` of the element 
 
       var msg = instance.locales[instance.language][instance.msgid];
       if (msg && msg.message) {
+        var message = msg.message,
+            paramCount = (message.match(/\$[0-9]+/g) || []).length,
+            parameters = instance.getAttribute('parameters');
+        if ((paramCount > 0) && (parameters)) {
+          parameters.split(';;').forEach(function(e,i) {
+            message = message.split('$'+i).join(e);
+          });
+        }
         instance.innerHTML = msg.message;
       }
     },


### PR DESCRIPTION
Added the parameters property, which makes possible to insert text (which requires no translations, such as numbers, names, dates) within messages. This feature exists in other frameworks such as Spring MVC and its MessageSource class.

Let's say we want to have a message like this: _Hello, my name is John Doe and I am from Seattle_.

In this example we have "John Doe" and "Seattle" as values which requires no translation. Actually, these values could come as dynamic values using {{}} or [[]]. So, in order to translate this kind of sentence it was required at least two messages, one for "Hello, my name is " and one for " and I am from ".
With the parameters property it's possible to insert both values within a unique message. To achieve this, the message in the locale should be writen as follows:
`Hello, my name is $0 and I am from $1`
Where $n is a pattern where the values will be inserted, being n a numeric value starting at zero. In the HTML the tag must be declared like this:
`<i18n-msg id="hello" parameters="John Doe;;Seattle"></i18n-msg>`
The values in parameters replace the patterns in the same numeric order they were declared in the message. In this case, $0 is replaced by "John Doe" and $1 is replaced by "Seattle". Also, it's possible to use dynamic values:
`<i18n-msg id="hello" parameters="{{user.name}};;{{user.city}}"></i18n-msg>`

TODO: create test for this feature and include in demo.
P.D.: sorry if my english is a bit confusing... I'm from Spain, actually it's a miracle I can write like this :P
Any suggestions for the code (and my writting skills) are welcome. ;)